### PR TITLE
Theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ src/templates/*
 
 # But don't ignore cv_template.html and cv_data.example.json
 !src/templates/cv_template.html
-!src/templates/cv_data.example.json
+!src/templates/cv_data.example.jsonc
 
 # Node modules
 node_modules/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-The CV Generator is a Node.js-based tool that dynamically generates a CV in PDF format. It leverages Handlebars for templating, Puppeteer for PDF generation, and includes built-in asset embedding for fonts, images, and icons. The project follows a modular ES Modules structure and is easily customizable.
+The CV Generator is a Node.js-based tool that dynamically generates a CV in PDF
+format. It leverages Handlebars for templating, Puppeteer for PDF generation,
+and includes built-in asset embedding for fonts, images, and icons. The project
+follows a modular ES Modules structure and is easily customizable.
 
 ## Features
 
@@ -29,7 +32,7 @@ cv-generator/
 │   │   ├── parseHtml.js     # Processes Handlebars templates into HTML
 │   ├── downloads/           # Stores generated PDF CVs
 │   ├── templates/           # Stores JSON data and HTML templates
-│   │   ├── cv_data.json     # The CV content in JSON format
+│   │   ├── cv_data.jsonc     # The CV content in JSON format
 │   │   ├── cv_template.html # Handlebars-based HTML template for the CV
 │   ├── index.js             # Main entry point for CV generation
 ├── .prettierrc              # Prettier configuration for code formatting
@@ -40,7 +43,8 @@ cv-generator/
 
 ## Installation
 
-Ensure you have [Node.js](https://nodejs.org/) installed, then clone the repository and install dependencies:
+Ensure you have [Node.js](https://nodejs.org/) installed, then clone the
+repository and install dependencies:
 
 ```sh
 npm install
@@ -48,7 +52,10 @@ npm install
 
 ## Usage
 
-Copy the `cv_data.example.json` or rename the file to `cv_data.json` and edit the json to your liking.
+First set up your CV Data by following
+[Setting up your JSON file](#setting-up-your-json-file) below.
+
+#### PDF Generation
 
 Run the following command to generate a CV:
 
@@ -56,45 +63,119 @@ Run the following command to generate a CV:
 npm start
 ```
 
-The generated PDF will be saved in the `downloads/` folder with a filename formatted as:
+The generated PDF will be saved in the `downloads/` folder with a filename
+formatted as:
 
 ```
 [FirstName] [LastName] CV [YYYY-MM-DD].pdf
 ```
 
-### Customizing the CV
+To generate a CV with a theme, run the following:
+
+```sh
+npm start [theme]
+```
+
+example: `npm start crimson`
+
+Learn more about themes [here](#theming)
+
+#### Web Preview
+
+Run the following command to start the web preview:
+
+```sh
+npm run preview
+```
+
+This will host a local web server [here](http://localhost:10000/) which shows
+you what your generated PDF will look like.
+
+This view is helpful for picking or editing themes.
+
+A theme for the preview can be selected by adding `?theme=[NAME_HERE]` to the
+end of the URL.
+
+Example:
+[http://localhost:10000?theme=crimson](http://localhost:10000?theme=crimson)
+
+## Customizing the CV
+
+#### Setting up your JSON file
+
+If you don't have a `src/templates/cv_data.json` file, copy the
+`cv_data.example.jsonc` file or rename the file to `cv_data.jsonc`.
 
 #### Editing CV Data
 
-The CV content is stored in `src/templates/cv_data.json`. Modify this file to update the CV details, such as personal information, skills, education, and work experience.
+The CV content is stored in `src/templates/cv_data.jsonc`. Modify this file to
+update the CV details, such as personal information, skills, education, and work
+experience.
 
 #### Customizing the Template
 
-The HTML template (`src/templates/cv_template.html`) uses Handlebars syntax for dynamic content rendering. You can modify this file to change the layout or structure of the CV.
+The HTML template (`src/templates/cv_template.html`) uses Handlebars syntax for
+dynamic content rendering. You can modify this file to change the layout or
+structure of the CV.
+
+## Theming
 
 #### Changing the Theme
 
 The CV supports multiple themes, including:
 
-- Bluewave (default)
-- Crimson
-- Gold
-- Verdant
-- Eclipse
+| Name         | Tag            |                   |
+| ------------ | -------------- | ----------------- |
+| Blue Wave    | `bluewave`     | The default theme |
+| Crimson      | `crimson`      |                   |
+| Gold         | `gold`         |                   |
+| Verdant      | `verdant`      |                   |
+| Eclipse      | `eclipse`      |                   |
+| Eclipse Dark | `eclipse.dark` |                   |
 
-You can specify the theme when running the script or modify the `theme` variable inside the `<script>` block in `cv_template.html`.
+The theme can be modified in your `cv_data.json` file.
 
-```
-const theme = "bluewave";
-```
+You can also specify the theme when [running the script](#pdf-generation), or by
+adding a URL parameter to the [web preview URL](#web-preview). This is helpful
+for testing multiple themes quickly when using the web priview, or or when you
+want to quickly export multiple CVs with different themes.
 
-#### Embedding Assets
+#### Creating or Modifying Themes
 
-Fonts, images, and icons are embedded as Base64 to ensure proper rendering in PDFs. The `embedAssets.js` module handles this automatically.
+Themes are kept in the `src/themes` folder, and can modify the following values:
+
+- Colors
+- Roundedness (`border-radius` of most elements)
+- Separate Header and Body Fonts
+
+> TODO: Add more customization
+
+To create a theme, simply copy `_example_theme_file.css`, name it according to
+the [tag](#theme-tags) you'd like and modify the values.
+
+##### Theme Tags
+
+The theme tag is the file name, without the `.css`. It is good practice to keep
+the theme tag name lowercase, with words separated by underscores.
+
+For multiple variants of the same theme, add the variant type to the end of the
+tag, starting with a period.
+
+> Examples theme file names:
+>
+>     my_long_theme_name.css
+>     my_long_theme_name.dark.css
+>     my_long_theme_name.amoled.css
+
+## Embedding Assets
+
+Fonts, images, and icons are embedded as Base64 to ensure proper rendering in
+PDFs. The `embedAssets.js` module handles this automatically.
 
 ## Code Style & Linting
 
-This project uses ESLint and Prettier for code consistency. Run the following commands for formatting and linting:
+This project uses ESLint and Prettier for code consistency. Run the following
+commands for formatting and linting:
 
 ```sh
 npm run format   # Auto-format code
@@ -112,4 +193,5 @@ npm run lint:fix # Fix linting issues
 
 ## Contributing
 
-Feel free to fork the repository and submit pull requests with improvements or new features.
+Feel free to fork the repository and submit pull requests with improvements or
+new features.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
+    "preview": "node src/preview.js",
     "format": "prettier --write \"**/*.{js,ts,html,css,md,json}\"",
     "lint": "eslint . ",
     "lint:fix": "eslint . --fix "

--- a/src/components/embedAssets.js
+++ b/src/components/embedAssets.js
@@ -25,32 +25,36 @@ export async function embedAssets(htmlContent) {
  */
 async function replaceAssetUrls(htmlContent, regex) {
   return htmlContent.replace(regex, (match, url) => {
-    const assetPath = path.resolve('./src/assets', url);
-    const fileBuffer = fs.readFileSync(assetPath);
-
-    const extname = path.extname(assetPath).toLowerCase();
-    let mimeType = '';
-
-    switch (extname) {
-      case '.woff2':
-        mimeType = 'application/font-woff2';
-        break;
-      case '.woff':
-        mimeType = 'application/font-woff';
-        break;
-      case '.ttf':
-        mimeType = 'application/font-ttf';
-        break;
-      case '.otf':
-        mimeType = 'application/font-opentype';
-        break;
-      default:
-        mimeType = 'application/octet-stream';
+    try {
+      const assetPath = path.resolve('./src/assets', url);
+      const fileBuffer = fs.readFileSync(assetPath);
+  
+      const extname = path.extname(assetPath).toLowerCase();
+      let mimeType = '';
+  
+      switch (extname) {
+        case '.woff2':
+          mimeType = 'application/font-woff2';
+          break;
+        case '.woff':
+          mimeType = 'application/font-woff';
+          break;
+        case '.ttf':
+          mimeType = 'application/font-ttf';
+          break;
+        case '.otf':
+          mimeType = 'application/font-opentype';
+          break;
+        default:
+          mimeType = 'application/octet-stream';
+      }
+  
+      const base64Encoded = fileBuffer.toString('base64');
+  
+      return `url('data:${mimeType};base64,${base64Encoded}')`;
+    } catch(_) {
+      return match;
     }
-
-    const base64Encoded = fileBuffer.toString('base64');
-
-    return `url('data:${mimeType};base64,${base64Encoded}')`;
   });
 }
 

--- a/src/components/parseCVData.js
+++ b/src/components/parseCVData.js
@@ -9,6 +9,10 @@ export async function parseCVData(filePath) {
   return new Promise((resolve, reject) => {
     fs.readFile(filePath, 'utf-8', (err, data) => {
       if (err) reject('Error reading CV data file.');
+
+      // remove comments
+      data = data.split(/[\r\n]+/g).filter(line => !line.match(/\s+\/\//)).join('\n');
+
       resolve(JSON.parse(data));
     });
   });

--- a/src/components/parseHtml.js
+++ b/src/components/parseHtml.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import Handlebars from 'handlebars';
+import { join } from "path";
 
 /**
  * Parses the HTML template with Handlebars and populates it with CV data.
@@ -7,12 +8,26 @@ import Handlebars from 'handlebars';
  * @param {Object} cvData - The CV data to inject into the template.
  * @returns {Promise<string>} - Returns the rendered HTML content.
  */
-export async function parseHtml(templateFilePath, cvData) {
+export async function parseHtml(templateFilePath, cvData, theme) {
   return new Promise((resolve, reject) => {
+    theme ||= cvData.theme;
+
+    let theme_css = null;
+    try {
+      theme_css = fs.readFileSync(join('src/themes', theme + '.css')).toString('utf-8');
+    } catch(_) {}
+
     fs.readFile(templateFilePath, 'utf-8', (err, template) => {
       if (err) reject('Error reading template file.');
       const compiledTemplate = Handlebars.compile(template);
-      const result = compiledTemplate(cvData);
+      let result = compiledTemplate(cvData);
+
+      if(theme_css) {
+        result = result.replace(/<style>[\r\n]+(\s+)@page/, (_, indent) => {
+          return `<style>\n${indent}${theme_css.replace(/\n/g, `\n${indent}`)}\n\n${indent}@page`;
+        })
+      }
+
       resolve(result);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -4,13 +4,15 @@ import { generatePdf } from './components/generatePdf.js';
 import { parseCVData } from './components/parseCVData.js';
 import { parseHtml } from './components/parseHtml.js';
 
-const cvDataPath = './src/templates/cv_data.json';
+const cvDataPath = './src/templates/cv_data.jsonc';
 const cvTemplatePath = './src/templates/cv_template.html';
 
 async function generateCV(cvDataFile, templateFile) {
   try {
+    const theme = process.argv[2];
+
     const cvData = await parseCVData(cvDataFile);
-    let htmlContent = await parseHtml(templateFile, cvData);
+    let htmlContent = await parseHtml(templateFile, cvData, theme);
     htmlContent = await embedAssets(htmlContent);
 
     const { firstName, lastName } = cvData;

--- a/src/preview.js
+++ b/src/preview.js
@@ -1,0 +1,26 @@
+import { embedAssets } from './components/embedAssets.js';
+import { parseCVData } from './components/parseCVData.js';
+import { parseHtml } from './components/parseHtml.js';
+
+import http from "http";
+
+const cvDataPath = './src/templates/cv_data.jsonc';
+const cvTemplatePath = './src/templates/cv_template.html';
+
+http.createServer({}, async (req, res) => {
+  if(req.url.match(/^\/\??/)) {
+    const theme = new URL('http://127.0.0.1' + req.url).searchParams.get('theme');
+
+    const cvData = await parseCVData(cvDataPath);
+    let htmlContent = await parseHtml(cvTemplatePath, cvData, theme);
+    htmlContent = await embedAssets(htmlContent);
+
+    res.write(htmlContent);
+    res.end();
+  }
+
+  res.statusCode = 404;
+  res.end();
+}).listen(10000, () => {
+  console.log(`CV Preview page listening at http://localhost:10000`);
+});

--- a/src/templates/cv_data.example.jsonc
+++ b/src/templates/cv_data.example.jsonc
@@ -1,4 +1,7 @@
 {
+  // bluewave | crimson | eclipse | gold | verdant
+  "theme": "bluewave",
+
   "firstName": "John",
   "lastName": "Doe",
   "currentRoleName": "Full-Stack Developer",

--- a/src/templates/cv_template.html
+++ b/src/templates/cv_template.html
@@ -10,6 +10,20 @@
 			size: A4;
 		}
 
+		:root {
+			/* Default colors: Bluewave */
+			--color-white: var(--theme-color-white, #ffffff);
+			--color-light: var(--theme-color-light, #d7d7d7);
+			--color-dark: var(--theme-color-dark, #1e1e1e);
+			--color-primary: var(--theme-color-primary, #1386C4);
+			--color-accent: var(--theme-color-accent, #292B2C);
+
+			--roundness: var(--theme-roundness, 5px);
+
+			--font-headers: var(--theme-font-headers, 'Roboto');
+			--font-body: var(--theme-font-body, 'Roboto');
+		}
+
 		@font-face {
 			font-family: "Roboto";
 			src: url("../assets/fonts/Roboto-VariableFont_wdth,wght.ttf") format("truetype");
@@ -19,15 +33,15 @@
 		}
 
 		body {
-			font-family: "Roboto", sans-serif;
+			font-family: var(--font-body);
 			font-weight: 400;
 			width: 210mm;
 			min-height: 297mm;
 			margin: 0 auto;
 			padding: 0;
 			line-height: 1.5;
-			background-color: var(--background);
-			color: var(--dark);
+			background-color: var(--color-background);
+			color: var(--color-dark);
 		}
 
 		.main-container {
@@ -39,17 +53,17 @@
 		.sidebar-container {
 			width: 30%;
 			min-height: 297mm;
-			background-color: var(--accent);
+			background-color: var(--color-accent);
 			display: flex;
 			flex-direction: column;
-			color: var(--light);
+			color: var(--color-light);
 			page-break-inside: avoid;
 		}
 
 		.profile-container {
 			width: 100px;
 			height: 100px;
-			background-color: var(--primary);
+			background-color: var(--color-primary);
 			border-radius: 50%;
 			margin: 20px auto;
 			display: flex;
@@ -72,6 +86,7 @@
 		.sidebar-title {
 			font-size: 18px;
 			font-weight: 700;
+			font-family: var(--font-headers);
 		}
 
 		.sidebar-content {
@@ -84,7 +99,7 @@
 		svg {
 			width: 20px;
 			height: 20px;
-			fill: var(--primary);
+			fill: var(--color-primary);
 		}
 
 		.sidebar-data {
@@ -97,13 +112,14 @@
 			display: flex;
 			flex-direction: row;
 			align-items: center;
+			font-family: var(--font-headers);
 		}
 
 		.education-dot {
 			width: 10px;
 			height: 10px;
-			border-radius: 50%;
-			background-color: var(--primary);
+			border-radius: var(--roundness);
+			background-color: var(--color-primary);
 		}
 
 		.education-name {
@@ -119,8 +135,8 @@
 
 		.education-line {
 			width: 5px;
-			background-color: var(--primary);
-			border-radius: 10px;
+			background-color: var(--color-primary);
+			border-radius: var(--roundness);
 			margin-left: 3px;
 		}
 
@@ -148,24 +164,24 @@
 
 		.skill-level {
 			width: 100%;
-			border: 1px solid var(--primary);
+			border: 1px solid var(--color-primary);
 			height: 5px;
-			border-radius: 5px;
+			border-radius: var(--roundness);
 		}
 
 		.skill-level-progress {
-			background-color: var(--primary);
+			background-color: var(--color-primary);
 			height: 100%;
-			border-radius: 5px;
+			border-radius: var(--roundness);
 		}
 
 		.information-container {
 			width: 70%;
 			min-height: 297mm;
-			background-color: var(--white);
+			background-color: var(--color-white);
 			display: flex;
 			flex-direction: column;
-			color: var(--dark);
+			color: var(--color-dark);
 		}
 
 		.header-container {
@@ -176,11 +192,13 @@
 		.header-title {
 			font-size: 40px;
 			font-weight: 900;
+			font-family: var(--font-headers);
 		}
-
+		
 		.header-role {
 			font-size: 18px;
 			font-weight: 500;
+			font-family: var(--font-headers);
 		}
 
 		.information-content-container {
@@ -192,7 +210,7 @@
 		.information-title {
 			font-size: 18px;
 			font-weight: 700;
-			border-bottom: 1px solid var(--primary);
+			border-bottom: 1px solid var(--color-primary);
 			margin-bottom: 12px;
 		}
 
@@ -233,8 +251,8 @@
 		.work-experience-description-dot {
 			width: 10px;
 			height: 10px;
-			border-radius: 50%;
-			background-color: var(--primary);
+			border-radius: var(--roundness);
+			background-color: var(--color-primary);
 			margin-top: 5px;
 		}
 
@@ -253,70 +271,12 @@
 		}
 
 		.work-experience-skill {
-			border: 1px solid var(--primary);
-			border-radius: 6px;
+			border: 1px solid var(--color-primary);
+			border-radius: var(--roundness);
 			padding: 0 5px;
 			margin: 5px;
 		}
 	</style>
-	<script>
-		document.addEventListener("DOMContentLoaded", function () {
-			// Bluewave 	- https://coolors.co/ffffff-d7d7d7-1e1e1e-1386c4-292b2c
-			// Crimson  	- https://coolors.co/ffffff-d7d7d7-1e1e1e-e44d4d-292b2c
-			// Gold 		- https://coolors.co/ffffff-d7d7d7-1e1e1e-f4b400-454647
-			// Verdant 		- https://coolors.co/ffffff-d7d7d7-1e1e1e-2fae50-454647
-			// Eclipse		- https://coolors.co/ffffff-d7d7d7-1e1e1e-8a2be2-454647
-
-			// Feel free to add your own theme
-
-			const themeColors = {
-				bluewave: {
-					white: "#ffffff",
-					light: "#d7d7d7",
-					dark: "#1e1e1e",
-					primary: "#1386C4",
-					accent: "#292B2C"
-				},
-				crimson: {
-					white: "#ffffff",
-					light: "#d7d7d7",
-					dark: "#1e1e1e",
-					primary: "#E44D4D",
-					accent: "#292B2C"
-				},
-				gold: {
-					white: "#ffffff",
-					light: "#d7d7d7",
-					dark: "#1e1e1e",
-					primary: "#F4B400",
-					accent: "#292B2C"
-				},
-				verdant: {
-					white: "#ffffff",
-					light: "#d7d7d7",
-					dark: "#1e1e1e",
-					primary: "#2FAE50",
-					accent: "#292B2C"
-				},
-				eclipse: {
-					white: "#ffffff",
-					light: "#d7d7d7",
-					dark: "#1e1e1e",
-					primary: "#8A2BE2",
-					accent: "#292B2C"
-				}
-			};
-
-			const theme = "bluewave";
-			const colors = themeColors[theme];
-
-			if (colors) {
-				Object.entries(colors).forEach(([key, value]) => {
-					document.documentElement.style.setProperty(`--${key}`, value);
-				});
-			}
-		});
-	</script>
 </head>
 
 <body>

--- a/src/themes/_example_theme_file.css
+++ b/src/themes/_example_theme_file.css
@@ -1,0 +1,12 @@
+/* Bluewave 	- https://coolors.co/ffffff-d7d7d7-1e1e1e-1386c4-292b2c */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #1386C4;
+  --theme-color-accent: #292B2C;
+
+  --theme-font-headers: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --theme-font-body: 'Lucida Console', monospace;
+}

--- a/src/themes/_example_theme_file.css
+++ b/src/themes/_example_theme_file.css
@@ -7,6 +7,7 @@
   --theme-color-primary: #1386C4;
   --theme-color-accent: #292B2C;
 
+  --theme-roundness: 5px;
   --theme-font-headers: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
   --theme-font-body: 'Lucida Console', monospace;
 }

--- a/src/themes/bluewave.css
+++ b/src/themes/bluewave.css
@@ -1,0 +1,12 @@
+/* Bluewave 	- https://coolors.co/ffffff-d7d7d7-1e1e1e-1386c4-292b2c */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #1386C4;
+  --theme-color-accent: #292B2C;
+
+  --theme-font-headers: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --theme-font-body: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}

--- a/src/themes/crimson.css
+++ b/src/themes/crimson.css
@@ -1,0 +1,9 @@
+/* Crimson  	- https://coolors.co/ffffff-d7d7d7-1e1e1e-e44d4d-292b2c */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #E44D4D;
+  --theme-color-accent: #292B2C;
+}

--- a/src/themes/eclipse.css
+++ b/src/themes/eclipse.css
@@ -1,0 +1,14 @@
+/* Eclipse		- https://coolors.co/ffffff-d7d7d7-1e1e1e-8a2be2-454647 */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #8A2BE2;
+  --theme-color-accent: #292B2C;
+
+  --theme-roundness: 2px;
+
+  --theme-font-headers: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --theme-font-body: 'Lucida Console', monospace;
+}

--- a/src/themes/eclipse.dark.css
+++ b/src/themes/eclipse.dark.css
@@ -1,0 +1,14 @@
+/* Eclipse Dark		- https://coolors.co/0a0212-d7d7d7-d7d7d7-8a2be2-1b1820 */
+
+:root {
+  --theme-color-white: #0a0212;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #d7d7d7;
+  --theme-color-primary: #8A2BE2;
+  --theme-color-accent: #1b1820;
+
+  --theme-roundness: 2px;
+
+  --theme-font-headers: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  --theme-font-body: 'Lucida Console', monospace;
+}

--- a/src/themes/gold.css
+++ b/src/themes/gold.css
@@ -1,0 +1,9 @@
+/* Gold 		- https://coolors.co/ffffff-d7d7d7-1e1e1e-f4b400-454647 */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #F4B400;
+  --theme-color-accent: #292B2C;
+}

--- a/src/themes/verdant.css
+++ b/src/themes/verdant.css
@@ -1,0 +1,9 @@
+/* Verdant 		- https://coolors.co/ffffff-d7d7d7-1e1e1e-2fae50-454647 */
+
+:root {
+  --theme-color-white: #ffffff;
+  --theme-color-light: #d7d7d7;
+  --theme-color-dark: #1e1e1e;
+  --theme-color-primary: #2FAE50;
+  --theme-color-accent: #292B2C;
+}


### PR DESCRIPTION
Added `preview.js` which hosts a local web page where your CV can be previewed without generating a PDF
Renamed `cv_data.json` to `cv_data.jsonc` to allow comments
Split themes into separate files
Added example `eclipse.dark` theme
Added theme customization functionality for header font, body font, roundness
Specify cv theme using `"theme": "[theme]"` in the `cv_data.jsonc` file
Added `npm run [theme]` argument to override the theme used for generation
Added `?theme=[theme]` URL param to override the theme used for preview